### PR TITLE
The @jitclass decorator requires new-style classes.

### DIFF
--- a/build_interface.py
+++ b/build_interface.py
@@ -379,7 +379,7 @@ def _write_class_specific(metadata, *pargs):
     ]
 
     @jitclass(spec)
-    class {name}():
+    class {name}(object):
 
         # set docstring
         __doc__ = _create_class_docstr(**mtdt['{name}'])


### PR DESCRIPTION
The `@jitclass` decorator requires new-style classes (at least in Numba >= 0.29.0). In the current code old-style classes are used, this PR fixes that. Allowing `rvlib` to be used with Numba 0.29.0.